### PR TITLE
"All Diagrams" background fix

### DIFF
--- a/Macro/Views/HomeView.swift
+++ b/Macro/Views/HomeView.swift
@@ -61,26 +61,29 @@ struct HomeView: View {
     func ListSidebarView() -> some View {
         List(selection: $selectedTopic) {
             Section{
-                NavigationLink(
-                    value: Topics(label: "All Diagrams", iconName: "tray.fill"),
+                NavigationLink(value: Topics(label: "All Diagrams", iconName: "tray.fill"),
                     label: {
                         HStack {
                             Image(systemName: "tray.fill")
                                 .foregroundColor(allDiagramsToggle ? .white : Color.primaryColor1)
+                                .padding(.leading, 10)
                             Text("All Diagrams")
                                 .foregroundColor(allDiagramsToggle ? .white : .black)
                         }
-                    }
-                ).background(allDiagramsToggle ? Color.primaryColor1 : nil)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical)
+                        .background(allDiagramsToggle ? Color.primaryColor1 : Color.clear)
+                        .clipShape(RoundedRectangle(cornerRadius: 7.0))
+                })
             }
-            Section("Topics", content: {
+            Divider()
+            Section {
                 ForEach(topics, id: \.self) { topicM in
-                    NavigationLink(
-                        value: topicM,
+                    NavigationLink(value: topicM,
                         label: {
                             HStack {
                                 Image(systemName: "\(topicM.iconName)")
-                                    .foregroundColor(selectedTopic == topicM ? .white : .primaryColor1)
+                                    .foregroundColor(selectedTopic == topicM ? .white : Color.primaryColor1)
                                 Text(topicM.label)
                             }
                         }
@@ -96,16 +99,16 @@ struct HomeView: View {
                         }
                     }
                 }
-            })
+            }
         }
         .onChange(of: selectedTopic, {
-            if selectedTopic == Topics(label: "All Diagrams", iconName: "tray.fill"){
+            if selectedTopic?.label == "All Diagrams" {
                 allDiagramsToggle = true
-            }else{
+            } else{
                 allDiagramsToggle = false
             }
         })
-        .navigationTitle("Topic list")
+        .navigationTitle("Categories")
         .toolbar {
             /* This is the button to add a new Topic in the Topic list */
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/Macro/Views/RectanglesOverlayView.swift
+++ b/Macro/Views/RectanglesOverlayView.swift
@@ -29,10 +29,10 @@ struct RectanglesOverlay: View {
                             context.fill(Path(rect), with: .color(.red.opacity(0.1))) // We change the color of the current rectangle
                         }
                     } else {
-                        context.fill(Path(rect), with: .color(.black.opacity(overlayVisibility ? 1.0 : 0.1)))
+                        context.fill(Path(rect), with: .color(Color(red: 53/255, green: 28/255, blue: 57/255).opacity(overlayVisibility ? 1.0 : 0.1)))
                     }
                 } else {
-                    context.fill(Path(rect), with: .color(.black.opacity(overlayVisibility ? 1.0 : 0.1)))
+                    context.fill(Path(rect), with: .color(Color(red: 53/255, green: 28/255, blue: 57/255).opacity(overlayVisibility ? 1.0 : 0.1)))
                 }
             }
         }


### PR DESCRIPTION
The background color bug in the 'All Diagrams' navigation link was fixed, and the color of unselected labels in the quiz was adjusted.